### PR TITLE
Fixed warnings on Visual C++ 2015

### DIFF
--- a/include/getopt.h
+++ b/include/getopt.h
@@ -423,11 +423,11 @@ namespace GetOpt
 						{
 							case FlagType::LONG:
 							case FlagType::LONG_SOLITARY:
-								foundHere = foundFlag = option.longOpts.count(arg);
+								foundHere = foundFlag = (option.longOpts.count(arg) > 0);
 								break;
 							case FlagType::SHORT:
 							case FlagType::SHORT_SOLITARY:
-								foundHere = foundFlag = option.shortOpts.count(arg[0]);
+								foundHere = foundFlag = (option.shortOpts.count(arg[0]) > 0);
 								break;
 							default:
 								throw std::logic_error("internal error: incorrect flag type after parse");
@@ -521,7 +521,7 @@ namespace GetOpt
 	void defaultGetoptPrinter(std::ostream& os, const std::string& message, std::vector<Option> options)
 	{
   		os << message << std::endl;
-		auto longestLong = 0;
+		size_t longestLong = 0;
 		for(auto& o : options)
 			for(auto& longOpt : o.longOpts)
 				if(longOpt.size() > longestLong)


### PR DESCRIPTION
Hi,

Here is a small change to make getopt.h compile with no warnings on Visual C++ 2015:
- I changed lines 426,430 to remove Visual C++ warning C4800 as explain in https://msdn.microsoft.com/en-us/library/b6801kcy.aspx
- I changed the 'auto' type to 'size_t' on line 524 because the 'auto' type resolves to 'int' which is signed, when longestLong is later compared to a 'size_t' expression which is unsigned, causing a compiler warning.

On a side note, I wanted a modern C++ getopt-like for my C++ project, and bothered to look at all the C++ getopts I found on github, and liked yours the most!

https://gist.github.com/udif/9a14fa6920bde6dfcb196779dc432bcc
